### PR TITLE
Tools Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ configtest.js
 
 # Data
 data
+!data/*.json

--- a/commands/info/tools.js
+++ b/commands/info/tools.js
@@ -1,0 +1,35 @@
+const tools = require('../../data/acnh-tools.json')
+
+module.exports.run = async (client, message, args, level, Discord) => {
+
+    if (!tools || tools.length === 0) return;
+
+    // embed
+    const embed = new Discord.MessageEmbed()
+        .setAuthor(message.author.tag, message.author.displayAvatarURL())
+        .setColor('#4199c2')
+        .setTimestamp()
+        .setFooter('Nookbot', client.user.displayAvatarURL());
+
+    tools.map(tool => {
+        const url = `[${tool.url}](${tool.url})`
+        embed.addField(tool.name, url, false)
+    })
+
+    return message.channel.send(embed);
+};
+
+module.exports.conf = {
+  guildOnly: false,
+  aliases: [],
+  permLevel: 'User',
+  args: 0,
+};
+
+module.exports.help = {
+  name: 'tools',
+  category: 'info',
+  description: 'Provides a list of popular, third-party apps and websites made for ACNH players.',
+  usage: 'tools',
+  details: '',
+};


### PR DESCRIPTION
Introduced a tools command for displaying a list of common third-party tools that assist ACNH players.

Tested and everything works, no extra permissions needed. Adds a `data/acnh-tools.json` file to add or remove tools at anytime.
![image](https://user-images.githubusercontent.com/8924090/80295901-c91f0280-8744-11ea-9411-82b690847d89.png)
