### PR TITLE
Set default allowedMentions to users only

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,9 @@ const client = new Discord.Client({
       Discord.Intents.FLAGS.DIRECT_MESSAGE_REACTIONS,
     ],
   },
+  allowedMentions: {
+    parse: ["users"]
+  }
 });
 const config = require('./config');
 const { version } = require('./package.json');


### PR DESCRIPTION
This should prevent users from being able to use the bot to ping @everyone, @here, and all roles. There may be commands that staff use where you would want to ping everyone, and you can manually enabled those pings on a per-message basis. This just turns them off by default.

Also, sorry for the ping in your server. Please be more careful as someone could easily have spammed @everyone and pinged like every role in the server.

-iWillBanU